### PR TITLE
chore: add docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  masa-tee-worker:
+    #    network_mode: "host"
+    image: masaengineering/tee-worker:main
+    # Uncomment to build from source
+    # build: .
+    ports:
+       - "8080:8080"
+    environment:
+      LISTEN_ADDRESS: ":8080"
+      # uncomment if not running with Intel SGX HW
+      # OE_SIMULATION: "1"
+    restart: always
+    # uncomment if running with Intel SGX
+    # devices:
+    # - /dev/sgx_enclave 
+    # - /dev/sgx_provision


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.yml` file to add a new service configuration for `masa-tee-worker`.

Service configuration addition:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R17): Added a new service `masa-tee-worker` with its image, ports, environment variables, and restart policy.