### PR TITLE
feat(api): switch to a nonce-based system

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ docker-compose up
 The tee-worker exposes a simple http API to submit jobs, retrieve results, and decrypt the results.
 
 ```bash
+SIG=$(curl localhost:8080/job/generate -H "Content-Type: application/json" -d '{ "type": "webscraper", "arguments": { "url": "google" } }')
 
 ### Submitting jobs
-curl localhost:8080/job -H "Content-Type: application/json" -d '{ "type": "webscraper", "arguments": { "url": "google" } }'
+curl localhost:8080/job/add -H "Content-Type: application/json" -d '{ "encrypted_job": "'$SIG'" }'
 
 ### Jobs results
-curl localhost:8080/job/b678ff77-118d-4a7a-a6ea-190eb850c28a
+result=$(curl localhost:8080/job/status/b678ff77-118d-4a7a-a6ea-190eb850c28a)
 
 ### Decrypt job results
-curl localhost:8080/decrypt -H "Content-Type: application/json" -d '{ "encrypted_result": "'$result'" }'
-
+curl localhost:8080/job/result -H "Content-Type: application/json" -d '{ "encrypted_result": "'$result'", "encrypted_request": "'$SIG'" }'
 ```
 
 ### Golang client
@@ -54,28 +54,39 @@ It is available a simple golang client to interact with the API:
 
 ```golang
 import(
-    	. "github.com/masa-finance/tee-worker/pkg/client"
-        "github.com/masa-finance/tee-worker/api/types"
+    . "github.com/masa-finance/tee-worker/pkg/client"
+    "github.com/masa-finance/tee-worker/api/types"
 )
 
 func main() {
+
     clientInstance := NewClient(server.URL)
 
     // Step 1: Create the job request
     job := types.Job{
         Type: "web-scraper",
         Arguments: map[string]interface{}{
-            "url": "google",
+            "url": "https://google.com",
+            "depth": 1,
         },
     }
 
-	// Step 2: Submit the job
-	jobID, err := clientInstance.SubmitJob(job)
+    // Step 2: Get a Job signature. Send the signature somewhere to be executed, or execute it locally (see below)
+    jobSignature, err := clientInstance.CreateJobSignature(job) 
 
-	// Step 3: Wait for the job result
-	encryptedResult, err := clientInstance.WaitForResult(jobID, 10, time.Second)
+	// Step 3: Submit the job signature for execution ( can be done locally or remotely )
+	jobResult, err := clientInstance.SubmitJob(jobSignature)
 
-	// Step 4: Decrypt the result
-	decryptedResult, err := clientInstance.DecryptResult(encryptedResult)
+    // Step 4a: Get the job result (decrypted)
+    result, err := jobResult.GetDecrypted(jobSignature)
+
+    // Alternatively, you can get the encrypted result and decrypt it later
+    // Note: this can be forwarded to another party to decrypt the result
+
+	// Step 4b.1: Get the job result (encrypted)
+	encryptedResult, err := jobResult.Get()
+
+    // Step 4b.2: Decrypt the result
+    decryptedResult, err := clientInstance.Decrypt(jobSignature, encryptedResult)
 }
 ```

--- a/api/types/encrypted.go
+++ b/api/types/encrypted.go
@@ -1,7 +1,33 @@
 package types
 
+import (
+	"encoding/json"
+
+	"github.com/masa-finance/tee-worker/pkg/tee"
+)
+
 type EncryptedRequest struct {
-	EncryptedResult string `json:"encrypted_result"`
+	EncryptedResult  string `json:"encrypted_result"`
+	EncryptedRequest string `json:"encrypted_request"`
+}
+
+func (payload EncryptedRequest) Unseal() (string, error) {
+	jobRequest, err := tee.Unseal(payload.EncryptedRequest)
+	if err != nil {
+		return "", err
+	}
+
+	job := Job{}
+	if err := json.Unmarshal(jobRequest, &job); err != nil {
+		return "", err
+	}
+
+	dat, err := tee.UnsealWithKey(job.Nonce, payload.EncryptedResult)
+	if err != nil {
+		return "", err
+	}
+
+	return string(dat), nil
 }
 
 type JobError struct {

--- a/api/types/job.go
+++ b/api/types/job.go
@@ -1,34 +1,15 @@
 package types
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
+	"github.com/masa-finance/tee-worker/pkg/tee"
+	"golang.org/x/exp/rand"
 )
 
-type JobResponse struct {
-	UID string `json:"uid"`
-}
-
 type JobArguments map[string]interface{}
-
-type JobResult struct {
-	Error string `json:"error"`
-	Data  []byte `json:"data"`
-}
-
-func (jr JobResult) Success() bool {
-	return jr.Error == ""
-}
-
-type Job struct {
-	Type      string       `json:"type"`
-	Arguments JobArguments `json:"arguments"`
-	UUID      string       `json:"-"`
-}
-
-func (jr JobResult) Unmarshal(i interface{}) error {
-	return json.Unmarshal(jr.Data, i)
-}
 
 func (ja JobArguments) Unmarshal(i interface{}) error {
 	dat, err := json.Marshal(ja)
@@ -38,8 +19,90 @@ func (ja JobArguments) Unmarshal(i interface{}) error {
 	return json.Unmarshal(dat, i)
 }
 
+type Job struct {
+	Type      string       `json:"type"`
+	Arguments JobArguments `json:"arguments"`
+	UUID      string       `json:"-"`
+	Nonce     string       `json:"quote"`
+}
+
+var letterRunes = []rune("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+// GenerateJobSignature generates a signature for the job.
+func (job *Job) GenerateJobSignature() (string, error) {
+	dat, err := json.Marshal(job)
+	if err != nil {
+		return "", err
+	}
+
+	checksum := sha256.New()
+	checksum.Write(dat)
+
+	job.Nonce = fmt.Sprintf("%s-%s", string(checksum.Sum(nil)), randStringRunes(99))
+
+	dat, err = json.Marshal(job)
+	if err != nil {
+		return "", err
+	}
+
+	return tee.Seal(dat)
+}
+
+type JobResponse struct {
+	UID string `json:"uid"`
+}
+
+type JobResult struct {
+	Error string `json:"error"`
+	Data  []byte `json:"data"`
+	Job   Job    `json:"job"`
+}
+
+// Success returns true if the job was successful.
+func (jr JobResult) Success() bool {
+	return jr.Error == ""
+}
+
+// Seal returns the sealed job result.
+func (jr JobResult) Seal() (string, error) {
+	return tee.SealWithKey(jr.Job.Nonce, jr.Data)
+}
+
+// Unmarshal unmarshals the job result data.
+func (jr JobResult) Unmarshal(i interface{}) error {
+	return json.Unmarshal(jr.Data, i)
+}
+
+type JobRequest struct {
+	EncryptedJob string `json:"encrypted_job"`
+}
+
+// DecryptJob decrypts the job request.
+func (jobRequest JobRequest) DecryptJob() (*Job, error) {
+	dat, err := tee.Unseal(jobRequest.EncryptedJob)
+	if err != nil {
+		return nil, err
+	}
+
+	job := Job{}
+	if err := json.Unmarshal(dat, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
 type JobConfiguration map[string]interface{}
 
+// Unmarshal unmarshals the job configuration into the supplied interface.
 func (jc JobConfiguration) Unmarshal(v interface{}) error {
 	data, err := json.Marshal(jc)
 	if err != nil {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/masa-finance/tee-worker/api/types"
+	"github.com/masa-finance/tee-worker/internal/jobserver"
+)
+
+func generate(c echo.Context) error {
+	job := &types.Job{}
+	if err := c.Bind(job); err != nil {
+		return err
+	}
+
+	encryptedSignature, err := job.GenerateJobSignature()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, types.JobError{Error: err.Error()})
+	}
+
+	return c.String(http.StatusOK, encryptedSignature)
+}
+
+func add(jobServer *jobserver.JobServer) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		jobRequest := types.JobRequest{}
+		if err := c.Bind(&jobRequest); err != nil {
+			return err
+		}
+
+		job, err := jobRequest.DecryptJob()
+		if err != nil {
+			return err
+		}
+
+		uuid := jobServer.AddJob(*job)
+
+		return c.JSON(http.StatusOK, types.JobResponse{UID: uuid})
+	}
+}
+
+func status(jobServer *jobserver.JobServer) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		res, exists := jobServer.GetJobResult(c.Param("job_id"))
+		if !exists {
+			return c.JSON(http.StatusNotFound, types.JobError{Error: "Job not found"})
+		}
+
+		if res.Error != "" {
+			return c.JSON(http.StatusInternalServerError, types.JobError{Error: res.Error})
+		}
+
+		sealedData, err := res.Seal()
+		if err != nil {
+			return err
+		}
+
+		return c.String(http.StatusOK, sealedData)
+
+	}
+}
+
+func result(c echo.Context) error {
+	payload := types.EncryptedRequest{
+		EncryptedResult:  "",
+		EncryptedRequest: "",
+	}
+
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	result, err := payload.Unseal()
+	if err != nil {
+		return err
+	}
+
+	return c.String(http.StatusOK, result)
+}

--- a/internal/api/start.go
+++ b/internal/api/start.go
@@ -2,14 +2,11 @@ package api
 
 import (
 	"context"
-	"encoding/base64"
-	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/masa-finance/tee-worker/api/types"
 	"github.com/masa-finance/tee-worker/internal/jobserver"
-	"github.com/masa-finance/tee-worker/pkg/tee"
 )
 
 func Start(ctx context.Context, listenAddress string, config types.JobConfiguration) {
@@ -27,82 +24,16 @@ func Start(ctx context.Context, listenAddress string, config types.JobConfigurat
 
 	// Routes
 	/*
-		- /job - POST - to send a job request
-		  A job request has a type (string) and a map[string]interface{} as parameter.
-		- /job/{job_id} - GET - to get the status of a job
-		- /decrypt - POST - to decrypt a message
-		  Decripts a message. Takes two parameters: the encrypted result and the encrypted request (both strings)
-
+		- POST /job/generate: Generate a job payload
+		- POST /job/add: Add a job to the queue
+		- GET /job/status/:job_id: Get the status of a job
+		- POST /job/result: Get the result of a job, decrypt it and return it
 	*/
-
-	/*
-			curl localhost:8080/job -H "Content-Type: application/json" -d '{
-		   "type": "webscraper", "arguments": { "url": "google" }
-		   }'
-
-	*/
-
-	e.POST("/job", func(c echo.Context) error {
-		job := types.Job{}
-		if err := c.Bind(&job); err != nil {
-			return err
-		}
-
-		uuid := jobServer.AddJob(job)
-
-		return c.JSON(http.StatusOK, types.JobResponse{UID: uuid})
-	})
-
-	/*
-		curl localhost:8080/job/b678ff77-118d-4a7a-a6ea-190eb850c28a
-	*/
-
-	e.GET("/job/:job_id", func(c echo.Context) error {
-		res, exists := jobServer.GetJobResult(c.Param("job_id"))
-		if !exists {
-			return c.JSON(http.StatusNotFound, types.JobError{Error: "Job not found"})
-		}
-
-		if res.Error != "" {
-			return c.JSON(http.StatusInternalServerError, types.JobError{Error: res.Error})
-		}
-
-		sealedData, err := tee.Seal(res.Data)
-		if err != nil {
-			return err
-		}
-
-		b64 := base64.StdEncoding.EncodeToString(sealedData)
-
-		return c.String(http.StatusOK, b64)
-	})
-
-	/*
-		curl localhost:8080/decrypt -H "Content-Type: application/json" -d '{ "encrypted_result": "'$result'" }'
-
-	*/
-
-	e.POST("/decrypt", func(c echo.Context) error {
-		payload := types.EncryptedRequest{
-			EncryptedResult: "",
-		}
-
-		if err := c.Bind(&payload); err != nil {
-			return err
-		}
-
-		b64, err := base64.StdEncoding.DecodeString(payload.EncryptedResult)
-		if err != nil {
-			return err
-		}
-
-		dat, err := tee.Unseal(b64)
-		if err != nil {
-			return err
-		}
-
-		return c.String(http.StatusOK, string(dat))
-	})
+	job := e.Group("/job")
+	job.POST("/generate", generate)
+	job.POST("/add", add(jobServer))
+	job.GET("/status/:job_id", status(jobServer))
+	job.POST("/result", result)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/jobserver/worker.go
+++ b/internal/jobserver/worker.go
@@ -50,6 +50,7 @@ func (js *JobServer) doWork(j types.Job) error {
 	}
 
 	js.Lock()
+	result.Job = j
 	js.results[j.UUID] = result
 	js.Unlock()
 

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -26,13 +26,40 @@ func NewClient(baseURL string) *Client {
 }
 
 // SubmitJob submits a new job to the server and returns the job result.
-func (c *Client) SubmitJob(job types.Job) (*JobResult, error) {
+func (c *Client) CreateJobSignature(job types.Job) (JobSignature, error) {
 	jobJSON, err := json.Marshal(job)
+	if err != nil {
+		return JobSignature(""), fmt.Errorf("error marshaling job: %w", err)
+	}
+
+	resp, err := c.HTTPClient.Post(c.BaseURL+"/job/generate", "application/json", bytes.NewBuffer(jobJSON))
+	if err != nil {
+		return JobSignature(""), fmt.Errorf("error sending POST request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return JobSignature(""), fmt.Errorf("error: received status code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return JobSignature(""), fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return JobSignature(string(body)), nil
+}
+
+// SubmitJob submits a new job to the server and returns the job result.
+func (c *Client) SubmitJob(JobSignature JobSignature) (*JobResult, error) {
+	jr := types.JobRequest{EncryptedJob: string(JobSignature)}
+
+	jobJSON, err := json.Marshal(jr)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling job: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Post(c.BaseURL+"/job", "application/json", bytes.NewBuffer(jobJSON))
+	resp, err := c.HTTPClient.Post(c.BaseURL+"/job/add", "application/json", bytes.NewBuffer(jobJSON))
 	if err != nil {
 		return nil, fmt.Errorf("error sending POST request: %w", err)
 	}
@@ -57,9 +84,10 @@ func (c *Client) SubmitJob(job types.Job) (*JobResult, error) {
 }
 
 // Decrypt sends the encrypted result to the server to decrypt it.
-func (c *Client) Decrypt(encryptedResult string) (string, error) {
+func (c *Client) Decrypt(JobSignature JobSignature, encryptedResult string) (string, error) {
 	decryptReq := types.EncryptedRequest{
-		EncryptedResult: encryptedResult,
+		EncryptedResult:  encryptedResult,
+		EncryptedRequest: string(JobSignature),
 	}
 
 	decryptReqJSON, err := json.Marshal(decryptReq)
@@ -67,19 +95,19 @@ func (c *Client) Decrypt(encryptedResult string) (string, error) {
 		return "", fmt.Errorf("error marshaling decrypt request: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Post(c.BaseURL+"/decrypt", "application/json", bytes.NewBuffer(decryptReqJSON))
+	resp, err := c.HTTPClient.Post(c.BaseURL+"/job/result", "application/json", bytes.NewBuffer(decryptReqJSON))
 	if err != nil {
-		return "", fmt.Errorf("error sending POST request to /decrypt: %w", err)
+		return "", fmt.Errorf("error sending POST request to /job/result: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error: received status code %d from /decrypt", resp.StatusCode)
+		return "", fmt.Errorf("error: received status code %d from /job/result", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading response body from /decrypt: %w", err)
+		return "", fmt.Errorf("error reading response body from /job/result: %w", err)
 	}
 
 	return string(body), nil
@@ -87,7 +115,7 @@ func (c *Client) Decrypt(encryptedResult string) (string, error) {
 
 // GetJobResult retrieves the encrypted result of a job.
 func (c *Client) GetResult(jobUUID string) (string, bool, error) {
-	resp, err := c.HTTPClient.Get(c.BaseURL + "/job/" + jobUUID)
+	resp, err := c.HTTPClient.Get(c.BaseURL + "/job/status/" + jobUUID)
 	if err != nil {
 		return "", false, fmt.Errorf("error sending GET request: %w", err)
 	}
@@ -106,6 +134,7 @@ func (c *Client) GetResult(jobUUID string) (string, bool, error) {
 	json.Unmarshal(body, &respErr)
 	if respErr.Error != "" {
 		err = fmt.Errorf("error: %s", respErr.Error)
+		return "", false, err
 	}
 
 	return string(body), true, err

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+type JobSignature string
+
 type JobResult struct {
 	UUID       string
 	maxRetries int
@@ -47,10 +49,10 @@ func (jr *JobResult) Get() (result string, err error) {
 }
 
 // Get polls the server until the job result is ready or a timeout occurs.
-func (jr *JobResult) GetDecrypted() (result string, err error) {
+func (jr *JobResult) GetDecrypted(js JobSignature) (result string, err error) {
 	result, err = jr.Get()
 	if err == nil {
-		result, err = jr.client.Decrypt(result)
+		result, err = jr.client.Decrypt(js, result)
 	}
 
 	return

--- a/pkg/tee/sealer.go
+++ b/pkg/tee/sealer.go
@@ -10,14 +10,47 @@ and provides just syntax sugar.
 
 */
 
-import "github.com/edgelesssys/ego/ecrypto"
+import (
+	"encoding/base64"
+
+	"github.com/edgelesssys/ego/ecrypto"
+)
 
 // Seal uses the TEE Product Key to encrypt the plaintext
 // The Product key is the one bound to the signer pubkey
-func Seal(plaintext []byte) ([]byte, error) {
-	return ecrypto.SealWithProductKey(plaintext, nil)
+func Seal(plaintext []byte) (string, error) {
+	return SealWithKey("", plaintext)
 }
 
-func Unseal(encryptedText []byte) ([]byte, error) {
-	return ecrypto.Unseal(encryptedText, nil)
+func Unseal(encryptedText string) ([]byte, error) {
+	return UnsealWithKey("", encryptedText)
+}
+
+func SealWithKey(key string, plaintext []byte) (string, error) {
+	additionalKey := []byte{}
+	if key != "" {
+		additionalKey = []byte(key)
+	}
+
+	res, err := ecrypto.SealWithProductKey(plaintext, additionalKey)
+	if err != nil {
+		return "", err
+	}
+
+	b64 := base64.StdEncoding.EncodeToString(res)
+	return b64, nil
+}
+
+func UnsealWithKey(key string, encryptedText string) ([]byte, error) {
+	additionalKey := []byte{}
+	if key != "" {
+		additionalKey = []byte(key)
+	}
+
+	b64, err := base64.StdEncoding.DecodeString(encryptedText)
+	if err != nil {
+		return nil, err
+	}
+
+	return ecrypto.Unseal(b64, additionalKey)
 }


### PR DESCRIPTION
this PR switches the logic to a nonce-based system. The job before being submitted needs to be used to generate a signature which is used to decrypt the result of the work executed inside the tee worker.

Closes: https://github.com/masa-finance/tee-worker/pull/18