### PR TITLE
fix: use TwitterResult rather than interface

### DIFF
--- a/internal/jobs/twitter.go
+++ b/internal/jobs/twitter.go
@@ -146,6 +146,7 @@ func (ts *TwitterScraper) ScrapeTweetsByQuery(baseDir string, query string, coun
 	}
 
 	ts.statsCollector.Add(stats.TwitterScrapes, 1)
+	var tweets []*TweetResult
 
 	// Check if we have a TwitterX API key
 	if apiKey != nil {
@@ -169,8 +170,8 @@ func (ts *TwitterScraper) ScrapeTweetsByQuery(baseDir string, query string, coun
 		return tweets, nil
 
 	}
+
 	// Use the default scraper if no TwitterX API key is available
-	var tweets []*TweetResult
 	ctx := context.Background()
 	scraper.SetSearchMode(twitterscraper.SearchLatest)
 

--- a/internal/jobs/twitter.go
+++ b/internal/jobs/twitter.go
@@ -59,7 +59,7 @@ func (ts *TwitterScraper) getAuthenticatedScraper(baseDir string) (*twitter.Scra
 
 	var scraper *twitter.Scraper
 	if account != nil {
-		
+
 		authConfig := twitter.AuthConfig{
 			Account: account,
 			BaseDir: baseDir,
@@ -139,7 +139,7 @@ func (ts *TwitterScraper) ScrapeTweetsProfile(baseDir string, username string) (
 	return profile, nil
 }
 
-func (ts *TwitterScraper) ScrapeTweetsByQuery(baseDir string, query string, count int) (interface{}, error) {
+func (ts *TwitterScraper) ScrapeTweetsByQuery(baseDir string, query string, count int) ([]*TweetResult, error) {
 	scraper, account, apiKey, err := ts.getAuthenticatedScraper(baseDir)
 	if err != nil {
 		return nil, err
@@ -156,10 +156,20 @@ func (ts *TwitterScraper) ScrapeTweetsByQuery(baseDir string, query string, coun
 		if err != nil {
 			return nil, err
 		}
-		ts.statsCollector.Add(stats.TwitterTweets, uint(len(result.Data)))
-		return result, nil
-	}
 
+		var tweets []*TweetResult
+		for _, tweet := range result.Data {
+			var newTweet twitterscraper.Tweet
+			newTweet.ID = tweet.ID
+			newTweet.Text = tweet.Text
+			tweets = append(tweets, &TweetResult{Tweet: &newTweet})
+		}
+
+		ts.statsCollector.Add(stats.TwitterTweets, uint(len(result.Data)))
+		return tweets, nil
+
+	}
+	// Use the default scraper if no TwitterX API key is available
 	var tweets []*TweetResult
 	ctx := context.Background()
 	scraper.SetSearchMode(twitterscraper.SearchLatest)


### PR DESCRIPTION
# Changes

- instead of using an `interface` for return, use the existing `TweetResult` by marshalling the result of the new API and setting the tweet ID and the tweet Text to it.
- this allows the API to use the same return as legacy. 