### PR TITLE
fix: add proper created_at using the timestamp from twitter

### DIFF
--- a/internal/jobs/twitter.go
+++ b/internal/jobs/twitter.go
@@ -19,7 +19,7 @@ import (
 )
 
 type TweetResult struct {
-	ID             int64
+	ID             int64 `json:"id"`
 	TweetID        string
 	ConversationID string
 	UserID         string
@@ -96,8 +96,9 @@ func (ts *TwitterScraper) convertTwitterScraperTweetToTweetResult(tweet twitters
 	}
 
 	// int64 timestamp to time.Time
-	createdAt := time.Unix(tweet.Timestamp, 0)
+	createdAt := time.Unix(tweet.Timestamp, 0).UTC()
 
+	logrus.Info("Tweet ID: ", id)
 	return TweetResult{
 		ID:             id,
 		TweetID:        tweet.ID,


### PR DESCRIPTION
# Changes

Add the proper `createdAt` value by converting the timestamp to `Time` object.

# Related PRs

https://github.com/masa-finance/tee-indexer/pull/50