### PR TITLE
feat: add skip verification config

### DIFF
--- a/internal/jobs/twitter.go
+++ b/internal/jobs/twitter.go
@@ -214,6 +214,7 @@ func (ts *TwitterScraper) getAuthenticatedScraper(j types.Job, baseDir string, j
 		authConfig := twitter.AuthConfig{
 			Account: account,
 			BaseDir: baseDir,
+			SkipLoginVerification: ts.configuration.SkipLoginVerification,
 		}
 
 		scraper = twitter.NewScraper(authConfig)
@@ -1044,9 +1045,10 @@ type TwitterScraper struct {
 }
 
 type TwitterScraperConfiguration struct {
-	Accounts []string `json:"twitter_accounts"`
-	ApiKeys  []string `json:"twitter_api_keys"`
-	DataDir  string   `json:"data_dir"`
+	Accounts             []string `json:"twitter_accounts"`
+	ApiKeys              []string `json:"twitter_api_keys"`
+	DataDir              string   `json:"data_dir"`
+	SkipLoginVerification bool     `json:"skip_login_verification,omitempty"` // If true, skips Twitter's verify_credentials check (default: false)
 }
 
 type TwitterScraperArgs struct {

--- a/internal/jobs/twitter/auth.go
+++ b/internal/jobs/twitter/auth.go
@@ -10,6 +10,10 @@ type AuthConfig struct {
 	// Account-based auth
 	Account *TwitterAccount
 	BaseDir string
+	// SkipLoginVerification when true, skips the IsLoggedIn check after loading cookies
+	// This can help avoid rate limiting on Twitter's verify_credentials endpoint
+	// Default is false (verification enabled)
+	SkipLoginVerification bool
 }
 
 func NewScraper(config AuthConfig) *Scraper {
@@ -21,6 +25,9 @@ func NewScraper(config AuthConfig) *Scraper {
 	}
 
 	scraper := &Scraper{Scraper: newTwitterScraper()}
+	
+	// Configure whether to skip login verification
+	scraper.SetSkipLoginVerification(config.SkipLoginVerification)
 
 	// Try loading cookies
 	if err := LoadCookies(scraper.Scraper, config.Account, config.BaseDir); err == nil {

--- a/internal/jobs/twitter/common.go
+++ b/internal/jobs/twitter/common.go
@@ -81,15 +81,19 @@ func getAuthenticatedScraper(baseDir string) (*Scraper, *TwitterAccount, error) 
 		return nil, nil, fmt.Errorf("all accounts are rate-limited")
 	}
 
+	// Check if we should skip login verification from environment
+	skipVerification := os.Getenv("TWITTER_SKIP_LOGIN_VERIFICATION") == "true"
+
 	authConfig := AuthConfig{
-		Account: account,
-		BaseDir: baseDir,
+		Account:               account,
+		BaseDir:               baseDir,
+		SkipLoginVerification: skipVerification,
 	}
 
 	scraper := NewScraper(authConfig)
 	if scraper == nil {
 		logrus.Errorf("Authentication failed for %s", account.Username)
-		return nil, account, fmt.Errorf("Twitter authentication failed for %s", account.Username)
+		return nil, account, fmt.Errorf("twitter authentication failed for %s", account.Username)
 	}
 	return scraper, account, nil
 }

--- a/internal/jobs/twitter/scraper.go
+++ b/internal/jobs/twitter/scraper.go
@@ -6,12 +6,27 @@ import (
 
 type Scraper struct {
 	*twitterscraper.Scraper
+	skipLoginVerification bool // false by default
 }
 
 func newTwitterScraper() *twitterscraper.Scraper {
 	return twitterscraper.New()
 }
 
+// SetSkipLoginVerification configures whether to skip the Twitter login verification API call
+// Setting this to true will avoid rate limiting on Twitter's verify_credentials endpoint
+func (s *Scraper) SetSkipLoginVerification(skip bool) *Scraper {
+	s.skipLoginVerification = skip
+	return s
+}
+
+// IsLoggedIn checks if the scraper is logged in
+// If skipLoginVerification is true, it will assume the session is valid without making an API call
 func (s *Scraper) IsLoggedIn() bool {
+	if s.skipLoginVerification {
+		return true // Skip the verification API call to avoid rate limits
+	}
+	
+	// Otherwise, perform the actual verification via API call
 	return s.Scraper.IsLoggedIn()
 }


### PR DESCRIPTION
# Changes

- add a skip verification to prevent rate limit issues

# How to test
set `TWITTER_SKIP_LOGIN_VERIFICATION` to `true` on .env config. If not set, it'll verify as per default.