### PR TITLE
fix: set bearer token regardless if we skip verification or not

### DIFF
--- a/internal/jobs/twitter/scraper.go
+++ b/internal/jobs/twitter/scraper.go
@@ -23,10 +23,14 @@ func (s *Scraper) SetSkipLoginVerification(skip bool) *Scraper {
 // IsLoggedIn checks if the scraper is logged in
 // If skipLoginVerification is true, it will assume the session is valid without making an API call
 func (s *Scraper) IsLoggedIn() bool {
+
+	// TODO: we somehow need to set the bearer token regardless. so calling this to set it.
+	// if the skip verification is set, we'll just return true.
+	loggedIn := s.Scraper.IsLoggedIn()
 	if s.skipLoginVerification {
 		return true // Skip the verification API call to avoid rate limits
 	}
-	
-	// Otherwise, perform the actual verification via API call
-	return s.Scraper.IsLoggedIn()
+
+	// whatever the scraper returns, we return
+	return loggedIn
 }


### PR DESCRIPTION
# Changes

- set the default bearer token if we skip verification.
- the scraper doesn't expose the setter so we need to call the isLogged() anyway to set the default bearer. 
- Need a better or more elegant solution here but that will require some changes to the scraper library which requires dependency upgrades / bumps etc. 