### PR TITLE
feat: fix tiktok transcription bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ test-jobs: docker-build-test
 test-twitter: docker-build-test
 	@docker run --user root $(ENV_FILE_ARG) -v $(PWD)/.masa:/home/masa -v $(PWD)/coverage:/app/coverage --rm --workdir /app -e DATA_DIR=/home/masa $(TEST_IMAGE) go test -v ./internal/jobs/twitter_test.go ./internal/jobs/jobs_suite_test.go
 
+test-tiktok: docker-build-test
+	@docker run --user root $(ENV_FILE_ARG) -v $(PWD)/.masa:/home/masa -v $(PWD)/coverage:/app/coverage --rm --workdir /app -e DATA_DIR=/home/masa $(TEST_IMAGE) go test -v ./internal/jobs/tiktok_transcription_test.go ./internal/jobs/jobs_suite_test.go
+
 test-web: docker-build-test
 	@docker run --user root $(ENV_FILE_ARG) -v $(PWD)/.masa:/home/masa -v $(PWD)/coverage:/app/coverage --rm --workdir /app -e DATA_DIR=/home/masa $(TEST_IMAGE) go test -v ./internal/jobs/webscraper_test.go ./internal/jobs/jobs_suite_test.go
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,8 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo-contrib v0.17.4
 	github.com/labstack/echo/v4 v4.13.4
-	github.com/masa-finance/tee-types v1.1.6
+	// FIXME: update to 1.1.7 once released
+	github.com/masa-finance/tee-types v1.1.7-0.20250815013733-31c068560772
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcX
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
-github.com/masa-finance/tee-types v1.1.6 h1:vw5gOK2ZoCnsmrjdY9NCUR9GY9c0VxvzwQy5V4sNemo=
-github.com/masa-finance/tee-types v1.1.6/go.mod h1:sB98t0axFlPi2d0zUPFZSQ84mPGwbr9eRY5yLLE3fSc=
+github.com/masa-finance/tee-types v1.1.7-0.20250815013733-31c068560772 h1:im/u4r8whAk3G0iPfgT7SGUBUb6lQb4HmSwG4nLaUeM=
+github.com/masa-finance/tee-types v1.1.7-0.20250815013733-31c068560772/go.mod h1:sB98t0axFlPi2d0zUPFZSQ84mPGwbr9eRY5yLLE3fSc=
 github.com/masa-finance/twitter-scraper v1.0.2 h1:him+wvYZHg/7EDdy73z1ceUywDJDRAhPLD2CSEa2Vfk=
 github.com/masa-finance/twitter-scraper v1.0.2/go.mod h1:38MY3g/h4V7Xl4HbW9lnkL8S3YiFZenBFv86hN57RG8=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/jobs/tiktok_transcription_test.go
+++ b/internal/jobs/tiktok_transcription_test.go
@@ -2,6 +2,7 @@ package jobs_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -41,10 +42,10 @@ var _ = Describe("TikTokTranscriber", func() {
 
 	Context("when a valid TikTok URL is provided", func() {
 		It("should successfully transcribe the video and record success stats", func(ctx SpecContext) {
-			videoURL := "https://www.tiktok.com/@coachty23/video/7502100651397172526"
+			videoURL := "https://www.tiktok.com/@.jake.ai/video/7516694182245813509"
 			jobArguments := map[string]interface{}{
 				"video_url": videoURL,
-				"language":  "eng-US", // Request a specific language
+				"language":  "ara-SA", // Request a specific language
 			}
 
 			job := types.Job{
@@ -80,6 +81,8 @@ var _ = Describe("TikTokTranscriber", func() {
 			if transcriptionResult.ThumbnailURL != "" {
 				Expect(strings.HasPrefix(transcriptionResult.ThumbnailURL, "http")).To(BeTrue(), "ThumbnailURL if present should be a valid URL")
 			}
+
+			fmt.Println("transcriptionResult: ", transcriptionResult)
 
 			By("Verifying success statistics")
 			Eventually(func() uint {


### PR DESCRIPTION
### What
The tiktok transcriber sometimes returns an array of transcriptions that contains what the user wants, and sometimes it does not.  Our previous fallback was to just return the first item in the array regardless -> this is bad.  Instead, we should return an error and the indexer will natively try another miner until either there is a match or we run out of miners...

### Why
The tiktok transcriber sometimes returned a weird language, and this is terrible UX.