### PR TITLE
chore: bump worker version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo-contrib v0.17.4
 	github.com/labstack/echo/v4 v4.13.4
-	github.com/masa-finance/tee-types v1.1.15
+	github.com/masa-finance/tee-types v1.1.16
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcX
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
-github.com/masa-finance/tee-types v1.1.15 h1:DfTNAYsG5g3XPxzJ2kw1bbT536mOeux3ZxaAq8XnNLg=
-github.com/masa-finance/tee-types v1.1.15/go.mod h1:sB98t0axFlPi2d0zUPFZSQ84mPGwbr9eRY5yLLE3fSc=
+github.com/masa-finance/tee-types v1.1.16 h1:tZCV908nFq3gh9E3kG/D436Y8Z2nQdRjo0YYwV4s43o=
+github.com/masa-finance/tee-types v1.1.16/go.mod h1:sB98t0axFlPi2d0zUPFZSQ84mPGwbr9eRY5yLLE3fSc=
 github.com/masa-finance/twitter-scraper v1.0.2 h1:him+wvYZHg/7EDdy73z1ceUywDJDRAhPLD2CSEa2Vfk=
 github.com/masa-finance/twitter-scraper v1.0.2/go.mod h1:38MY3g/h4V7Xl4HbW9lnkL8S3YiFZenBFv86hN57RG8=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/versioning/version.go
+++ b/internal/versioning/version.go
@@ -5,5 +5,5 @@ var (
 
 	// XXX: Bump this value only when there are protocol changes that makes the oracle
 	// incompatible between version!
-	TEEWorkerVersion = `beta`
+	TEEWorkerVersion = `gamma`
 )


### PR DESCRIPTION
### What
This will essentially "force" miners to upgrade to the latest worker, as the Bittensor validators will only score miners who have a version that matches "latest"

### Why
We want all of our miners to run the latest and greatest version of the worker for release today